### PR TITLE
Update Isolation Forest pipeline to use new merge_dataset

### DIFF
--- a/Back_End/Scripts/iso_train.py
+++ b/Back_End/Scripts/iso_train.py
@@ -15,49 +15,131 @@ def load_s3_csv(bucket, key):
 # Load dataset from S3 bucket
 iso_train = load_s3_csv("noumi-datasets", "iso_train.csv")
 iso_test = load_s3_csv("noumi-datasets", "iso_test.csv")
+
+# Store transaction_id and date for later use, ensure they are from the test set
+# and align with X_test before it's modified (e.g. dropping columns).
+# It's crucial that store_date and store_ids are taken *before* X_test is redefined with only feature columns.
+iso_test_original_indices = iso_test.index # Keep original indices if any shuffling or reindexing happens
 store_date = iso_test['date'].copy()
+store_ids = iso_test['transaction_id'].copy() # Assuming 'transaction_id' is present for identifying transactions
 
-# Features
+
+# Features - Updated to reflect merge_dataset.csv structure
+# We need to select numerical features that are suitable for Isolation Forest.
+# Categorical features like 'merchant_name', 'merchant_category' would need encoding (e.g., one-hot or target encoding).
+# For now, let's select a revised set of numerical and potentially some easily encodable categoricals if necessary,
+# or focus on numerical ones first.
+# Date components like month, day, day_of_week can be extracted if deemed useful.
+
+# Convert 'date' to datetime and extract features
+iso_train['date'] = pd.to_datetime(iso_train['date'])
+iso_test['date'] = pd.to_datetime(iso_test['date'])
+
+iso_train['month'] = iso_train['date'].dt.month
+iso_train['day'] = iso_train['date'].dt.day
+iso_train['day_of_week'] = iso_train['date'].dt.dayofweek # Monday=0, Sunday=6
+
+iso_test['month'] = iso_test['date'].dt.month
+iso_test['day'] = iso_test['date'].dt.day
+iso_test['day_of_week'] = iso_test['date'].dt.dayofweek
+
+# One-hot encode 'day_of_week'
+iso_train = pd.get_dummies(iso_train, columns=['day_of_week'], prefix='dow')
+iso_test = pd.get_dummies(iso_test, columns=['day_of_week'], prefix='dow')
+
+# Define features to use for the model
+# Focusing on numerical features from merge_dataset.csv
+# 'amount' is key. 'balance_at_txn_time' could be useful.
+# Calculated features like 'days_since_txn', 'total_spent_30d', 'total_income_30d',
+# 'txn_count_30d', 'avg_txn_amt_30d', 'std_txn_amt_30d', 'net_cash_flow_30d', 'savings_delta'
+# are likely very informative.
 columns_to_keep = [
-    'amount', 'month', 'day',
-    'rolling_spend_7d', 'prev_transaction_amt',
-    'day_of_week_Friday', 'day_of_week_Monday', 'day_of_week_Saturday',
-    'day_of_week_Sunday', 'day_of_week_Thursday', 'day_of_week_Tuesday', 'day_of_week_Wednesday',
-    'local_time_bucket_Night', 'local_time_bucket_Morning', 'local_time_bucket_Afternoon',
-    'local_time_bucket_Evening', 'local_time_bucket_Late Night',
-    'is_weekend_False', 'is_weekend_True'
+    'amount', 'balance_at_txn_time', 'monthly_income',
+    'suggested_savings_amount', 'available', 'days_since_txn',
+    'total_spent_30d', 'total_income_30d', 'txn_count_30d',
+    'avg_txn_amt_30d', 'std_txn_amt_30d', 'net_cash_flow_30d', 'savings_delta',
+    'month', 'day', # Extracted date features
+    # Add one-hot encoded day_of_week columns (example, adjust based on actual dummy columns created)
+    # These will be like dow_0, dow_1, ..., dow_6
 ]
+# Add dow columns dynamically
+dow_cols_train = [col for col in iso_train.columns if 'dow_' in col]
+dow_cols_test = [col for col in iso_test.columns if 'dow_' in col]
+# Ensure consistency in columns between train and test after one-hot encoding
+common_dow_cols = list(set(dow_cols_train) & set(dow_cols_test))
+columns_to_keep.extend(common_dow_cols)
 
-# Cast to float
-X_train = iso_train[columns_to_keep].astype(float)
-X_test = iso_test[columns_to_keep].astype(float)
+# Align columns for train and test sets to ensure they are identical
+# This handles cases where a particular day of week might not be in one of the splits
+all_possible_dow_cols = [f'dow_{i}' for i in range(7)]
+for col in all_possible_dow_cols:
+    if col not in iso_train.columns:
+        iso_train[col] = 0
+    if col not in iso_test.columns:
+        iso_test[col] = 0
+# Re-ensure common_dow_cols includes all dow_0 to dow_6 if they were added.
+columns_to_keep = [c for c in columns_to_keep if 'dow_' not in c] # remove previous dow entries
+columns_to_keep.extend(all_possible_dow_cols) # add all possible ones
+columns_to_keep = list(set(columns_to_keep)) # Remove duplicates if any
+
+
+# Handle potential missing columns if a feature is not present in the dataset
+# (e.g. if 'std_txn_amt_30d' is all NaN for some reason and gets dropped, or if merge_dataset is different)
+final_columns_to_keep_train = [col for col in columns_to_keep if col in iso_train.columns]
+final_columns_to_keep_test = [col for col in columns_to_keep if col in iso_test.columns]
+
+# Ensure X_train and X_test have the exact same columns in the same order
+# This is critical if some features were entirely missing in one set after preproc, or if a dow wasn't present.
+common_features = list(set(final_columns_to_keep_train) & set(final_columns_to_keep_test))
+
+X_train = iso_train[common_features].astype(float).fillna(0) # Fill NaNs with 0, a common strategy
+X_test = iso_test[common_features].astype(float).fillna(0)   # Fill NaNs with 0
+
+# Re-align store_date and store_ids with X_test's final indices if any filtering/dropping happened
+# This is important because train_test_split shuffles, and further operations might re-index.
+# Using .loc with original indices of iso_test ensures correct alignment.
+store_date = iso_test.loc[X_test.index, 'date']
+store_ids = iso_test.loc[X_test.index, 'transaction_id']
+
 
 # Initialize isolation forest from sklearn
-clf = IsolationForest(contamination=0.05, random_state=100)
+clf = IsolationForest(contamination=0.05, random_state=100) # Contamination can be tuned
 clf.fit(X_train)
 
 # Store model.pkl
-with open('../Models/isolation_forest_model.pkl', 'wb') as f:
+model_path = '../Models/isolation_forest_model.pkl'
+with open(model_path, 'wb') as f:
     pickle.dump(clf, f)
+print(f"Model saved to {model_path}")
 
 # Compute anomaly scores 
 scores = clf.decision_function(X_test) # Predicts the anomalous score
-preds = clf.predict(X_test) # Binary classification (anomaly / non-anomaly) 
+preds = clf.predict(X_test) # Binary classification (anomaly / non-anomaly), -1 for outliers, 1 for inliers
 
-# Align anomaly scores with date
+# Align anomaly scores with date and transaction_id
 result_df = pd.DataFrame({
+    'transaction_id': store_ids,
     'date': store_date,
     'anomaly_score': scores,
-    'anomaly_label': preds  
+    'anomaly_label': preds
 })
 
-# Save to CSV
-csv_buffer = io.StringIO()
-result_df.to_csv(csv_buffer, index=False)
+# Save to CSV locally in Database/Anomaly_Scores
+output_dir = "../Database/Anomaly_Scores"
+import os
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+output_path = os.path.join(output_dir, "isolation_forest_anomaly_scores.csv")
 
-# Upload to S3
-s3.put_object(
-    Bucket='noumi-datasets',
-    Key='iso_results/anomaly_scores.csv',
-    Body=csv_buffer.getvalue()
-)
+result_df.to_csv(output_path, index=False)
+print(f"Anomaly scores saved to {output_path}")
+
+# Upload to S3 (Commented out as per request to save locally first)
+# csv_buffer = io.StringIO()
+# result_df.to_csv(csv_buffer, index=False)
+# s3.put_object(
+#     Bucket='noumi-datasets', # S3 bucket remains the same if needed in future
+#     Key='iso_results/anomaly_scores.csv', # S3 key remains the same
+#     Body=csv_buffer.getvalue()
+# )
+# print("Anomaly scores also uploaded to S3: s3://noumi-datasets/iso_results/anomaly_scores.csv")

--- a/Back_End/Scripts/split_dataset.py
+++ b/Back_End/Scripts/split_dataset.py
@@ -9,26 +9,47 @@ s3 = boto3.client('s3')
 
 def load_s3_csv(bucket, key):
     obj = s3.get_object(Bucket=bucket, Key=key)
-    return pd.read_csv(io.BytesIO(obj['Body'].read())) # Return bytes
+    return pd.read_csv(io.BytesIO(obj['Body'].read()))
 
-# LSTM dataset
-df_lstm = load_s3_csv("noumi-datasets", "processed_50000_for_lstm.csv") # Load as a dictionary
+# Load the merged dataset
+# df_iso = load_s3_csv("noumi-datasets", "merge_dataset.csv") # Assuming it's uploaded to S3
+# For local testing, assuming merge_dataset.csv is in Back_End/Database/
+try:
+    df_iso = pd.read_csv('../Database/merge_dataset.csv')
+except FileNotFoundError:
+    print("Error: merge_dataset.csv not found. Make sure it's in the Back_End/Database/ directory or adjust the path.")
+    exit()
 
-# Isolation Forest dataset
-df_iso = load_s3_csv("noumi-datasets", "processed_5000.csv")
+
+# LSTM dataset (Commented out as per request)
+# df_lstm = load_s3_csv("noumi-datasets", "processed_50000_for_lstm.csv")
+
+# Isolation Forest dataset (using the new merge_dataset.csv)
+# df_iso = load_s3_csv("noumi-datasets", "processed_5000.csv") # Old line
 
 # Split the dataset
-df_lstm = df_lstm.sort_values('date')
-train_lstm, val_lstm, test_lstm = np.split(df_lstm, [int(.7*len(df_lstm)), int(.85*len(df_lstm))])
+# df_lstm = df_lstm.sort_values('date') # LSTM part
+# train_lstm, val_lstm, test_lstm = np.split(df_lstm, [int(.7*len(df_lstm)), int(.85*len(df_lstm))]) # LSTM part
 
-train_iso, test_iso = train_test_split(df_iso, test_size=0.2, random_state=100)
+# Ensure 'date' column is in datetime format if it's being used for sorting or time-based splits
+# For Isolation Forest, if 'date' is not directly used in splitting strategy other than being a column,
+# direct train_test_split is fine.
+# If a chronological split is needed for iso as well, df_iso should be sorted by date first.
+# Assuming a random split is acceptable for Isolation Forest as per the original script.
+df_iso['date'] = pd.to_datetime(df_iso['date']) # Ensure date is in correct format for potential sorting
+df_iso = df_iso.sort_values('date') # Optional: sort if a chronological split is preferred for consistency, though random_state is used.
+
+train_iso, test_iso = train_test_split(df_iso, test_size=0.2, random_state=100) #Original split strategy for iso
 
 # Save split files back to S3 for training
-fs = s3fs.S3FileSystem()
+fs = s3fs.S3FileSystem() # This requires s3fs and appropriate AWS credentials configured
 
-train_lstm.to_csv('s3://noumi-datasets/lstm_train.csv', index=False)
-val_lstm.to_csv('s3://noumi-datasets/lstm_val.csv', index=False)
-test_lstm.to_csv('s3://noumi-datasets/lstm_test.csv', index=False)
+# LSTM part (Commented out)
+# train_lstm.to_csv('s3://noumi-datasets/lstm_train.csv', index=False)
+# val_lstm.to_csv('s3://noumi-datasets/lstm_val.csv', index=False)
+# test_lstm.to_csv('s3://noumi-datasets/lstm_test.csv', index=False)
 
 train_iso.to_csv('s3://noumi-datasets/iso_train.csv', index=False)
 test_iso.to_csv('s3://noumi-datasets/iso_test.csv', index=False)
+
+print("Dataset splitting complete. Isolation forest train and test sets saved to S3.")


### PR DESCRIPTION
- Modify split_dataset.py to read from Back_End/Database/merge_dataset.csv.
- Comment out LSTM-related processing in split_dataset.py.
- Update iso_train.py to use relevant numerical features from the new dataset, including extracted date components and one-hot encoded day_of_week.
- Handle potential NaN values in features by filling with 0.
- Save the trained Isolation Forest model to Back_End/Models/.
- Save anomaly scores locally to Back_End/Database/Anomaly_Scores/isolation_forest_anomaly_scores.csv, now including transaction_id for better identification.